### PR TITLE
Use dune.2.0.1

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,3 +1,4 @@
-(lang dune 1.11)
+(lang dune 2.0)
+(name vocal)
 (using menhir 2.0)
-(using fmt 1.2 (enabled_for dune))
+(formatting (enabled_for dune))

--- a/gospel.opam
+++ b/gospel.opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {>= "1.11.1"}
+  "dune" {>= "2.0.1"}
   "menhir"
   "ocaml" {>= "4.07"}
 ]

--- a/vocal.opam
+++ b/vocal.opam
@@ -27,6 +27,6 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {>= "1.11.1"}
+  "dune" {>= "2.0.1"}
   "ocaml" {>= "4.07"}
 ]

--- a/why3gospel.opam
+++ b/why3gospel.opam
@@ -18,7 +18,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {>= "1.11.1"}
+  "dune" {>= "2.0.1"}
   "why3"
   "gospel"
   "ocaml" {>= "4.07"}


### PR DESCRIPTION
This updates the dune version, as it seems that the variables for build artefacts ([here](https://github.com/vocal-project/vocal/blob/master/why3gospel/dune#L19)) are actually only available since dune.2.0.1.
