### PR TITLE
Fix compatibility with OCaml > 4.07

### DIFF
--- a/gospel/ocaml-lib/misc.ml
+++ b/gospel/ocaml-lib/misc.ml
@@ -606,6 +606,14 @@ module Color = struct
   (* add color handling to formatter [ppf] *)
   let set_color_tag_handling ppf =
     let open Format in
+    (* XXX These functions are depreciated since 4.08. This should be removed
+       when support for 4.07 is dropped. *)
+    let[@warning "-3"] pp_get_formatter_tag_functions =
+      pp_get_formatter_tag_functions
+    in
+    let[@warning "-3"] pp_set_formatter_tag_functions =
+      pp_set_formatter_tag_functions
+    in
     let functions = pp_get_formatter_tag_functions ppf () in
     let functions' = {functions with
       mark_open_tag=(mark_open_tag ~or_else:functions.mark_open_tag);

--- a/gospel/ocaml-lib/numbers.ml
+++ b/gospel/ocaml-lib/numbers.ml
@@ -77,7 +77,7 @@ module Float = struct
   include Identifiable.Make (struct
     type t = float
 
-    let compare x y = Pervasives.compare x y
+    let compare = Float.compare
     let output oc x = Printf.fprintf oc "%f" x
     let hash f = Hashtbl.hash f
     let equal (i : float) j = i = j


### PR DESCRIPTION
The warnings-as-errors policy in `dune` makes gospel incompatible with OCaml > 4.07 because `Pervasives` and `Format.pp_set_formatter_tag_functions` are depreciated. This PR removes the former and adds a local warning disable to the later. 