### PR TITLE
Use relative paths

### DIFF
--- a/gospel/ocaml-lib/parser_frontend.mli
+++ b/gospel/ocaml-lib/parser_frontend.mli
@@ -10,30 +10,30 @@
 (********************************************************************)
 
 exception Ocaml_syntax_error of Location.t
-exception FileNotFound of string
 
-(** `parse_ocaml load_path file` parses the OCaml content of the
-   `file` if it is a valid interface. If `file` is relative, it
-   searches for `file` in the `load_path`.
+(** [with_loadpath loadpath filename] finds the first directory [d] in
+   [loadpath] such that [d/filename] is a valid file path, and returns it. If
+   [filename] is an absolute valid path or is ["gospelstdlib.mli"], it returns
+   it unchanged. Raises Not_found if no such path exists. *)
+val with_loadpath : string list -> string -> string
 
-   Raise FileNotFound if file does not exist.
+(** `parse_ocaml file` parses the OCaml content of the `file` if it is a valid
+   interface.
 
+   Raise Not_found if file does not exist.
    Raise Ocaml_syntax_error if there is an OCaml syntax error. *)
-val parse_ocaml : string list -> string -> Oparsetree.signature
+val parse_ocaml : string -> Oparsetree.signature
 
 val parse_ocaml_lb : Lexing.lexbuf -> Oparsetree.signature
 
-(** `parse_gospel sig_list name` parses the GOSPEL attributes and
+(** [parse_gospel sig_list name] parses the GOSPEL attributes and
    integrates them in the corresponding OCaml signatures. *)
 val parse_gospel :
   Oparsetree.signature_item list -> string -> Uast.s_signature_item list
 
-(** `parse_ocaml_gospel load_path file` parses the OCaml interface and
-   the GOSPEL specification of `file`. If `file` is relative, it
-   searches for `file` in the `load_path`.
+(** [parse_ocaml_gospel file] parses the OCaml interface and
+   the GOSPEL specification of `file`.
 
-   Raise FileNotFound if file does not exist.
-
+   Raise Not_found if file does not exist.
    Raise Ocaml_syntax_error if there is an OCaml syntax error. *)
-val parse_ocaml_gospel :
-  string list -> string -> string -> Uast.s_signature_item list
+val parse_ocaml_gospel :  string -> string -> Uast.s_signature_item list

--- a/gospel/tools/gospel_tc.ml
+++ b/gospel/tools/gospel_tc.ml
@@ -34,7 +34,7 @@ let run_bench () =
   let ok,error = ref 0, ref 0 in
   let parse f =
     try
-      let ocaml = parse_ocaml !load_path f in
+      let ocaml = parse_ocaml f in
       let module_nm = path2module f in
       let sigs  =  parse_gospel ocaml module_nm in
       ok := !ok + 1;
@@ -51,7 +51,7 @@ let run_bench () =
 
 let run_on_file file =
   try
-    let ocaml = parse_ocaml !load_path file in
+    let ocaml = parse_ocaml file in
     if !print_intermediate then begin
         pp fmt "@[@\n ********* Parsed file - %s *********@\n@]@." file;
         pp fmt "@[%a@]@." Opprintast.signature ocaml
@@ -76,10 +76,10 @@ let run_on_file file =
     pp fmt "@[@\n*** OK ***@\n@]@."
   with
   | Exit -> ()
-  | FileNotFound f ->
+  | Not_found ->
      let open Format in
      eprintf  "File %s not found.@\nLoad path: @\n%a@\n@."
-       f (pp_print_list ~pp_sep:pp_print_newline pp_print_string)
+       file (pp_print_list ~pp_sep:pp_print_newline pp_print_string)
        !Options.load_path
   | e -> Location.report_exception Format.err_formatter e
 

--- a/gospel/tools/options.ml
+++ b/gospel/tools/options.ml
@@ -12,11 +12,11 @@ open Arg
 
 (** Get *.mli files in directory *)
 let mli_in_dir dir =
-  let files = Sys.readdir dir in
-  let files = Array.to_list files in
   let is_mli f = Filename.extension f = ".mli" in
-  let mli = List.filter is_mli files in
-  List.map ((^) dir) mli
+  Sys.readdir dir
+  |> Array.to_list
+  |> List.filter is_mli
+  |> List.rev_map (Filename.concat dir)
 
 let valid_dir d =
   try if Sys.is_directory d then d else raise Exit with
@@ -49,14 +49,12 @@ let specialist = [
 let anon_fun s =
   let open Filename in
   let open Sys in
-  let absolute s =
-    if is_relative s then concat (getcwd ()) s else s in
   if file_exists s && is_directory s then begin
-    files := List.rev (mli_in_dir (absolute s)) @ !files;
-    load_path := (absolute s) :: !load_path
+    files := mli_in_dir s @ !files;
+    load_path := s :: !load_path
   end else begin
-      files := absolute s :: !files;
-      load_path := absolute (dirname s) :: !load_path
+      files := s :: !files;
+      load_path := dirname s :: !load_path
     end
 
 let usage_msg = "Usage: gospel <options> file.mli [file.mli]"


### PR DESCRIPTION
The overall goal I'm trying to achieve is to have regression tests based on the output of `gospel_tc --print-intermediate` (or similar), so we can detect changes at every step.

A blocker is that `gospel` uses absolute - thus not reproducible - paths when manipulating filenames. This PR is an attempt to switch to relative paths. 