### PR TITLE
Upgrade to dune.2.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,13 @@
 ##########################################################################
 
 all:
-	$(MAKE) gospel
-	$(MAKE) why3gospel
-	$(MAKE) vocal
+	dune build
+
+install:
+	dune build @install && dune install
+
+test:
+	dune build @runtest
 
 gospel:
 	dune build @install -p gospel && dune install gospel

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.0)
+(lang dune 2.4)
 (name vocal)
 (using menhir 2.0)
 (formatting (enabled_for dune))

--- a/gospel.opam
+++ b/gospel.opam
@@ -22,7 +22,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {>= "2.0.1"}
+  "dune" {>= "2.4.0"}
   "menhir"
   "ocaml" {>= "4.07"}
 ]

--- a/vocal.opam
+++ b/vocal.opam
@@ -27,6 +27,6 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {>= "2.0.1"}
+  "dune" {>= "2.4.0"}
   "ocaml" {>= "4.07"}
 ]

--- a/vocal/proofs/why3/gospel.mlw
+++ b/vocal/proofs/why3/gospel.mlw
@@ -1,1 +1,0 @@
-../../why3gospel/gospel.mlw

--- a/why3gospel.opam
+++ b/why3gospel.opam
@@ -18,7 +18,7 @@ build: [
   ["dune" "runtest" "-p" name] {with-test}
 ]
 depends: [
-  "dune" {>= "2.0.1"}
+  "dune" {>= "2.4.0"}
   "why3"
   "gospel"
   "ocaml" {>= "4.07"}

--- a/why3gospel/dune
+++ b/why3gospel/dune
@@ -1,27 +1,14 @@
-(library
- (public_name why3gospel)
+(executable
  (flags :standard -w -9-32-27 -linkall)
- (library_flags -linkall)
- (modules why3gospel_driver why3gospel_trans why3gospel)
- (libraries why3 gospel))
-
-;; cf https://discuss.ocaml.org/t/dune-problems-using-dynlink-plugins/2874
-;; In this rule, `gospel` is used in the action but is out of the scope of dune
-;; understanding, so scheduling issues can occur when running `dune build` for
-;; the whole project. Either use `-j 1`, build `gospel` before `why3gospel`
-;; manually, or restart the build after the failure
-;; Reported in https://github.com/ocaml/dune/issues/3136
-
-(rule
- (targets plugin_why3gospel.cmxs)
- (action
-  (run ocamlfind ocamlopt -shared -linkall -linkpkg -package gospel
-    %{cmxa:why3gospel} -o %{targets})))
+ (name why3gospel)
+ (modes plugin)
+ (libraries why3 gospel)
+ (embed_in_plugin_libraries gospel))
 
 (install
  (section lib_root)
  (files
-  (plugin_why3gospel.cmxs as why3/plugins/plugin_why3gospel.cmxs))
+  (why3gospel.cmxs as why3/plugins/plugin_why3gospel.cmxs))
  (package why3gospel))
 
 (install


### PR DESCRIPTION
Dune 2.4.0 is being released (we have to wait for https://github.com/ocaml/opam-repository/pull/15956 to be merged), and includes a build mode for plugins.
This will simplify the build rule of why3gospel, and allow us to build the repository as a whole, e.g. use `dune build` or `dune runtest` on the whole repository (and fix the CI by the way).
I modified the behaviour of `make` (and `make all`) to build only, and added `make install` to install (former `make`), because that sounds more intuitive to me, but this can be reverted.