### PR TITLE
Add Utils interface

### DIFF
--- a/gospel/ocaml-lib/tmodule.ml
+++ b/gospel/ocaml-lib/tmodule.ml
@@ -16,6 +16,8 @@ open Tast
 
 (** Namespace *)
 
+module Mstr = Map.Make(String)
+
 type namespace = {
     ns_ts  : tysymbol  Mstr.t;
     ns_ls  : lsymbol   Mstr.t;

--- a/gospel/ocaml-lib/typing.mli
+++ b/gospel/ocaml-lib/typing.mli
@@ -9,7 +9,6 @@
 (*                                                                  *)
 (********************************************************************)
 
-open Utils
 open Tast
 open Tmodule
 
@@ -19,7 +18,7 @@ type parse_env
 (** `penv load_paths module_nm` creates a `parse_env` for typing a
    module with name `module_nm`. The paths in `load_paths` are to be
    used when searching for modules dependencies. *)
-val penv : string list -> Sstr.t -> parse_env
+val penv : string list -> Utils.Sstr.t -> parse_env
 
 (** `process_sig_item penv muc s` returns a new module under
    construction after type checking `s` and the typed signature

--- a/gospel/ocaml-lib/uattr2spec.ml
+++ b/gospel/ocaml-lib/uattr2spec.ml
@@ -352,7 +352,7 @@ and module_type_desc m =
   | Pmty_signature s ->
      Mod_signature (signature s)
   | Pmty_functor (l,m1,m2) ->
-     Mod_functor (l,Utils.opmap module_type m1, module_type m2)
+     Mod_functor (l, Option.map module_type m1, module_type m2)
   | Pmty_with (m,c) ->
      Mod_with (module_type m, List.map with_constraint c)
   | Pmty_typeof m ->
@@ -374,6 +374,6 @@ and module_declaration m =
 and module_type_declaration m =
   let attrs, specs = get_spec_attrs m.pmtd_attributes in
   let mtd = { mtdname = m.pmtd_name;
-              mtdtype = Utils.opmap module_type m.pmtd_type;
+              mtdtype = Option.map module_type m.pmtd_type;
               mtdattributes = attrs; mtdloc = m.pmtd_loc} in
   mtd, specs

--- a/gospel/ocaml-lib/uparser.mly
+++ b/gospel/ocaml-lib/uparser.mly
@@ -162,14 +162,14 @@ func:
   { let ps = match ps with | None -> [] | Some ps -> ps in
     let spec = match spec with
         None -> empty_fspec | Some spec -> rev_fspec spec in
-    { fun_name = fname; fun_rec = Utils.opt2bool r; fun_type = Some ty;
+    { fun_name = fname; fun_rec = Utils.Option.is_some r; fun_type = Some ty;
       fun_params = ps; fun_def = def; fun_spec = spec;
       fun_loc = mk_loc $startpos $endpos} }
 | PREDICATE r=REC? fname=func_name ps=params
     def=preceded(EQUAL, term)? spec=func_spec?
   { let spec = match spec with
         None -> empty_fspec | Some spec -> rev_fspec spec in
-    { fun_name = fname; fun_rec = Utils.opt2bool r; fun_type = None;
+    { fun_name = fname; fun_rec = Utils.Option.is_some r; fun_type = None;
       fun_params = ps; fun_def = def; fun_spec = spec ;
       fun_loc = mk_loc $startpos $endpos} }
 ;

--- a/gospel/ocaml-lib/utils.mli
+++ b/gospel/ocaml-lib/utils.mli
@@ -1,0 +1,70 @@
+module Option : sig
+  val value : 'a option -> default:'a -> 'a
+  (** [value o ~default] is [v] if [o] is [Some v] and default otherwise. *)
+
+  val get : 'a option -> 'a
+  (** [get o] is [v] if [o] is [Some v]. Raises Invalid_argument otherwise. *)
+
+  val map : ('a -> 'b) -> 'a option -> 'b option
+  (** [map f o] is [None] if [o] is [None] and [Some (f v)] is [o] is [Some v]. *)
+
+  val iter : ('a -> unit) -> 'a option -> unit
+  (** [iter f o] is [f v] if [o] is [Some] v and [()] otherwise. *)
+
+  val is_some : 'a option -> bool
+  (** [is_some o] is [true] iff [o] is [Some o]. *)
+end
+
+val split_at_f : ('a -> bool) -> 'a list -> 'a list * 'a list
+(** [split_at_f f l] is the partition [(l1, l2)] such that [l1] is the longest
+    prefix where the predicate [f] holds. The order of the elements is not
+    changed. *)
+
+val split_at_i : int -> 'a list -> 'a list * 'a list
+(** [split_at_i i l] is the partition [(l1, l2)] such that [l1] contains the
+    first i elements. The order of the elements is not changed. *)
+
+val pp_print_option :
+  ?none:(Format.formatter -> unit -> unit) ->
+  (Format.formatter -> 'a -> unit) ->
+  Format.formatter ->
+  'a option ->
+  unit
+(** [pp_print_option ?none pp_v ppf o] prints [o] on [ppf] using [pp_v] if [o]
+    is [Some v] and [none] if it is [None]. [none] prints nothing by default. *)
+
+val list_with_first_last :
+  ?sep:Opprintast.space_formatter ->
+  ?first:Opprintast.space_formatter ->
+  ?last:Opprintast.space_formatter ->
+  (Format.formatter -> 'a -> unit) ->
+  Format.formatter ->
+  'a list ->
+  unit
+
+exception TypeCheckingError of string
+
+exception NotSupported of string
+
+exception Located of Location.t * exn
+
+val error : ?loc:Location.t -> exn -> 'a
+(** [error ?loc e] raises [e], wrapped in [Located(loc, e)] if [loc] is
+    provided. *)
+
+val check : ?loc:Location.t -> bool -> exn -> unit
+(** [check ?loc b e] checks if [b] is true, otherwise raises [e], wrapped in
+    [Located(loc, e)] if [loc] is provided. *)
+
+val error_report : ?loc:Location.t -> string -> 'a
+(** [error_report ?loc e] is [error ?loc (TypeCheckingError s)]. *)
+
+val check_report : ?loc:Location.t -> bool -> string -> unit
+(** [check_report ?loc b e] is [check ?loc b (TypeCheckingError s)]. **)
+
+val not_supported : ?loc:Location.t -> string -> 'a
+(** [not_supported ?loc s] raises [NotSupported s], wrapped in [Located(loc, e)]
+    if [loc] is provided. *)
+
+(** String sets. *)
+module Sstr : Set.S with type elt = string


### PR DESCRIPTION
This PR adds a documented interface for `Utils`. The goal is to have a well defined signature, reduced if possible.
Most of the noticeable changes are:
- I renamed the functions on options to match the ones in the standard library (starting 4.08).
- Hash tables are no longer specialized when there is no need too (i.e. when the `hash` or `equal` functions are not specific), so we don't need them in `Utils` anymore. `create` is now all called with `0` instead of various values.