### PR TITLE
Unpin why3

### DIFF
--- a/why3gospel.opam
+++ b/why3gospel.opam
@@ -19,11 +19,7 @@ build: [
 ]
 depends: [
   "dune" {>= "2.4.0"}
-  "why3"
+  "why3" {>= "1.3.0"}
   "gospel"
   "ocaml" {>= "4.07"}
-]
-
-pin-depends: [
-  [ "why3.dev" "git+https://gitlab.inria.fr/why3/why3.git#f40af3b05ee9b553e90be5a7b04d7fdf4d26f780" ]
 ]


### PR DESCRIPTION
Since `why3` was released with the missing values, there is no need to pin it anymore.