### PR TITLE
Remove redundant argument in Parser_frontend.parse_ocaml_gospel

### DIFF
--- a/gospel/src/parser_frontend.ml
+++ b/gospel/src/parser_frontend.ml
@@ -67,5 +67,10 @@ let parse_gospel sign nm =
   if nm = gospelstdlib then signature sign else
     default_open :: signature sign
 
-let parse_ocaml_gospel file =
-  parse_ocaml file |> parse_gospel
+let path2module p =
+  Filename.basename p |> Filename.chop_extension |> String.capitalize_ascii
+
+let parse_ocaml_gospel path =
+  let module_name = path2module path in
+  let ocaml = parse_ocaml path in
+  parse_gospel ocaml module_name

--- a/gospel/src/parser_frontend.mli
+++ b/gospel/src/parser_frontend.mli
@@ -12,28 +12,28 @@
 exception Ocaml_syntax_error of Location.t
 
 (** [with_loadpath loadpath filename] finds the first directory [d] in
-   [loadpath] such that [d/filename] is a valid file path, and returns it. If
-   [filename] is an absolute valid path or is ["gospelstdlib.mli"], it returns
-   it unchanged. Raises Not_found if no such path exists. *)
+    [loadpath] such that [d/filename] is a valid file path, and returns it. If
+    [filename] is an absolute valid path or is ["gospelstdlib.mli"], it returns
+    it unchanged. Raises Not_found if no such path exists. *)
 val with_loadpath : string list -> string -> string
 
 (** `parse_ocaml file` parses the OCaml content of the `file` if it is a valid
-   interface.
+    interface.
 
-   Raise Not_found if file does not exist.
-   Raise Ocaml_syntax_error if there is an OCaml syntax error. *)
+    Raise Not_found if file does not exist.
+    Raise Ocaml_syntax_error if there is an OCaml syntax error. *)
 val parse_ocaml : string -> Oparsetree.signature
 
 val parse_ocaml_lb : Lexing.lexbuf -> Oparsetree.signature
 
-(** [parse_gospel sig_list name] parses the GOSPEL attributes and
-   integrates them in the corresponding OCaml signatures. *)
+(** [parse_gospel sig_list module_name] parses the GOSPEL attributes and
+    integrates them in the corresponding OCaml signatures. *)
 val parse_gospel :
-  Oparsetree.signature_item list -> string -> Uast.s_signature_item list
+  Oparsetree.signature -> string -> Uast.s_signature
 
-(** [parse_ocaml_gospel file] parses the OCaml interface and
-   the GOSPEL specification of `file`.
+(** [parse_ocaml_gospel path] parses the OCaml interface and the GOSPEL
+    specification of the file located in [path].
 
-   Raise Not_found if file does not exist.
-   Raise Ocaml_syntax_error if there is an OCaml syntax error. *)
-val parse_ocaml_gospel :  string -> string -> Uast.s_signature_item list
+    Raise Not_found if the file does not exist. Raise Ocaml_syntax_error if
+    there is an OCaml syntax error. *)
+val parse_ocaml_gospel :  string -> Uast.s_signature

--- a/gospel/src/typing.ml
+++ b/gospel/src/typing.ml
@@ -742,7 +742,7 @@ let rec open_file ~loc penv muc nm =
     let file_nm  = String.uncapitalize_ascii nm ^ ".mli" in
     let sl =
       let file = Parser_frontend.with_loadpath penv.lpaths file_nm in
-      Parser_frontend.parse_ocaml_gospel file nm
+      Parser_frontend.parse_ocaml_gospel file
     in
     let muc = open_empty_module muc nm in
     let penv = {penv with parsing = Sstr.add nm penv.parsing} in


### PR DESCRIPTION
The current signature for `parse_ocaml_gospel` is `string -> string -> Uast.signature`.
Besides having two unnamed arguments of the same type - which can be misleading, also because it's not documented - the second argument (module name) could easily be inferred from the first one (path).
This PR does just that. 